### PR TITLE
Dependencies not in public repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<description>nexr-hive-udf</description>
 
 	<properties>
-		<hadoop.version>0.20.2-cdh3u2</hadoop.version>
+		<hadoop.version>0.20.2</hadoop.version>
 		<hive.version>0.9.0</hive.version>
 	</properties>
 
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>javax.jdo</groupId>
 			<artifactId>jdo2-api</artifactId>
-			<version>2.3-ec</version>
+			<version>2.3-eb</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>


### PR DESCRIPTION
Fixed dependencies in pom.xml.

a) refer to standard Apache Hadoop artifact instead of special vender specific one
b) change jdo to refer to latest released version (eb instead of ec)

There are no tests so I can't tell if this breaks things or not. Pity.

```
ted:hive-udf[master]$ mvn -q test

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
There are no tests to run.

Results :

Tests run: 0, Failures: 0, Errors: 0, Skipped: 0

ted:hive-udf[master]$ 
```
